### PR TITLE
Set GPIO 23 HIGH to keep SMPS PWM mode.

### DIFF
--- a/SimpleAudioFilter02/SimpleAudioFilter02.ino
+++ b/SimpleAudioFilter02/SimpleAudioFilter02.ino
@@ -33,6 +33,10 @@ void setup() {
 #ifdef DEBUG_SERIAL 
   Serial.begin(115200);
 #endif  
+
+  // Keep SMPS PWM mode to reduce audio noise. (RPi Pico Dataseet p.18)
+  pinMode(23, OUTPUT);
+  digitalWrite(23, HIGH);
   
   // initialize digital pin LED_BUILTIN as an output.
   gpio_init_mask(1<<LED_BUILTIN);  


### PR DESCRIPTION
RPi Pico has onboard SMPS (DC-DC converter) for power management. The SMPS has PWM and PFM mode. Unfortunately, PFM mode produces audio noise.
We can keep SMPS PWM mode by setting GPIO 23 HIGH.

Please see p.18 of RPi Pico datasheet.
https://datasheets.raspberrypi.com/pico/pico-datasheet.pdf