### PR TITLE
Migration to the Earlephilhower's Arduino core.

### DIFF
--- a/SimpleAudioFilter02/audioIO.cpp
+++ b/SimpleAudioFilter02/audioIO.cpp
@@ -38,6 +38,8 @@
 #include "hardware/dma.h"
 #include "pico/multicore.h"
 
+#include "hardware/pwm.h"
+
 #define FSAMP 480000UL       // freq AD sample  = 480kHz
 #define FSAMP_AUDIO 48000U   // audio freq sample   48kHz
 #define ADC_CLOCK_DIV ((uint16_t)(48000000UL/FSAMP))  //48Mhz / 480Khz = 100 


### PR DESCRIPTION
The Earlephilhower's Arduino core is based on RPi Pico C/C++ SDK so it supports overclocking.
https://github.com/earlephilhower/arduino-pico

To enable migration to the Earlephilhower's Arduino core, I added include hardware/pwm.h statement.