### PR TITLE
Convert a 12-bit ADC reading to a 15-bit data.

### DIFF
--- a/SimpleAudioFilter06/SimpleAudioFilter06.ino
+++ b/SimpleAudioFilter06/SimpleAudioFilter06.ino
@@ -61,15 +61,11 @@ void onReceiveAudioSamples(){
     
     sample = adcIn.read();
 
-    sample = sample - ADC_BIAS -ADC_BIAS_SHIFT;
+    sample = (sample - ADC_BIAS -ADC_BIAS_SHIFT)*8;
 
      CW1Filter_put(&flt1, sample);
      sample = CW1Filter_get(&flt1);
 
-     sample = sample + ADC_BIAS +ADC_BIAS_SHIFT;
-     
-
-    
     // write the same sample twice, once for left and once for the right channel
     i2s.write(sample);
     i2s.write(sample);


### PR DESCRIPTION
The adcIn.read() generates 12bit data. I modify the code to convert a 12-bit ADC reading to a 15-bit data by multiplying by 8. It can enables us to get more big output sound and more better dynamic range. According to my test, just converting 12-bit to 16-bit by multiplying by 16 causes noise when over-ranging. The one bit may be remaining for filtering.